### PR TITLE
mac drivers can be 64 bit as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ class BuildScripts(build_scripts):
         architecture = 32
         if plat.startswith('darwin'):
             os_ = 'mac'
+            architecture = platform.architecture()[0][:-3]
         elif plat.startswith('linux'):
             os_ = 'linux'
             architecture = platform.architecture()[0][:-3]


### PR DESCRIPTION
Updates setup.py to consider 64 bit driver for mac since google doesn't appear to keep a 32 bit version up to date
